### PR TITLE
Makes use of Data.Void from `void` / `base`.

### DIFF
--- a/generics-eot.cabal
+++ b/generics-eot.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.18.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -28,6 +28,7 @@ library
   build-depends:
       base == 4.*
     , markdown-unlit
+    , void
   exposed-modules:
       Generics.Eot
       Generics.Eot.Tutorial
@@ -42,7 +43,7 @@ test-suite quickcheck
   main-is: Spec.hs
   hs-source-dirs:
       test/quickcheck
-    , src
+      src
   ghc-options: -Wall -fno-warn-name-shadowing -pgmL markdown-unlit
   build-depends:
       base == 4.*
@@ -67,8 +68,8 @@ test-suite spec
   main-is: Spec.hs
   hs-source-dirs:
       test
-    , src
-    , examples
+      src
+      examples
   ghc-options: -Wall -fno-warn-name-shadowing -pgmL markdown-unlit
   build-depends:
       base == 4.*
@@ -77,8 +78,10 @@ test-suite spec
     , QuickCheck
     , interpolate
     , doctest
+    , contravariant
   other-modules:
       Examples.CatamorphismsSpec
+      Examples.ContraSpec
       Examples.DocsSpec
       Examples.MinBoundSpec
       Examples.ToStringSpec

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,8 @@ library:
     - Generics.Eot.Tutorial
   source-dirs:
     - src
+  dependencies:
+    - void
 
 tests:
   spec:
@@ -36,6 +38,7 @@ tests:
       - QuickCheck
       - interpolate
       - doctest
+      - contravariant
 
   quickcheck:
     main: Spec.hs

--- a/src/Generics/Eot.hs
+++ b/src/Generics/Eot.hs
@@ -17,14 +17,14 @@ module Generics.Eot (
   Constructor(..),
   Fields(..),
 
-  -- * Void
-  Void,
   -- * Useful Re-exports
   Generic,
   Proxy(..),
+  Void
   ) where
 
 import           Data.Proxy
+import           Data.Void
 import           GHC.Exts (Constraint)
 import           GHC.Generics hiding (Datatype, Constructor)
 

--- a/src/Generics/Eot/Eot.hs
+++ b/src/Generics/Eot/Eot.hs
@@ -15,10 +15,10 @@
 
 module Generics.Eot.Eot (
   HasEotG(..),
-  Void,
   ) where
 
 import           Data.Proxy
+import           Data.Void
 import           GHC.Generics
 
 -- * datatype
@@ -56,14 +56,6 @@ instance HasFieldsG f => HasConstructorsG (C1 c f) where
   fromEotConstructors = \ case
     Left fields -> M1 $ fromEotFields fields
     Right void -> seq void (error "impossible")
-
--- | Uninhabited type.
-data Void
-  deriving (Generic)
-
-deriving instance Show Void
-deriving instance Eq Void
-deriving instance Ord Void
 
 instance HasConstructorsG V1 where
   type Constructors V1 = Void

--- a/test/Examples/ContraSpec.hs
+++ b/test/Examples/ContraSpec.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+
+module Examples.ContraSpec where
+
+import           Test.Hspec
+
+import           Generics.Eot
+
+import           Data.Void
+import           Data.Functor.Contravariant
+import           Data.Functor.Contravariant.Divisible
+
+newtype Serializer a = Serializer { runSerializer :: a -> String }
+
+string :: Serializer String
+string = Serializer id
+
+int :: Serializer Int
+int = Serializer show
+
+instance Contravariant Serializer where
+  contramap f (Serializer g) = Serializer (g . f)
+
+instance Divisible Serializer where
+  conquer = Serializer (const mempty)
+
+  divide toBC (Serializer sb) (Serializer sc) = Serializer $ \a ->
+    case toBC a of
+      (b, c) ->
+        let bBytes = sb b
+            cBytes = sc c
+        in bBytes ++ cBytes
+
+instance Decidable Serializer where
+  lose f = Serializer $ \a -> absurd (f a)
+  choose split l r = Serializer $ \a ->
+    either (runSerializer l) (runSerializer r) (split a)
+
+data Identifier = StringId String | IntId Int
+  deriving (Eq, Ord, Show, Generic)
+
+identifier :: Serializer Identifier
+identifier = contramap toEot $
+  chosen (divided string conquer) $
+  chosen (divided int conquer) $
+  lost
+
+spec :: Spec
+spec = do
+  describe "contravariant" $ do
+    it "allows you to use Decidable with Void" $ do
+      runSerializer identifier (StringId "hi") `shouldBe` "hi"
+      runSerializer identifier (IntId 4) `shouldBe` "4"


### PR DESCRIPTION
The `void` package takes care of the transition for us.

In the general case, this is for greater compatiblity with
`base` / the Haskell ecosystem at large.

My specific desire for the change comes from the fact that
`generics-eot` and some of the classes in `contravariant` go
together particularly well, and the latter works with the
`Void` from `Data.Void`.

Fixes #6.