### PR TITLE
fix .ghci file

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,2 +1,3 @@
 :set -isrc -itest -iexamples -Wall -fno-warn-name-shadowing
 :set -pgmL markdown-unlit
+:set -optP-include -optP.stack-work/dist/x86_64-linux-nopie/Cabal-1.22.4.0/build/autogen/cabal_macros.h


### PR DESCRIPTION
This allows to run the test suite with
```
$ stack exec ghci test/Spec.hs
*Main> spec
```
(After running `stack test`.)

This is for faster execution during development.