### PR TITLE
put less things in scope of the test code for quickcheck tests

### DIFF
--- a/test/quickcheck/DatatypeSpec.hs
+++ b/test/quickcheck/DatatypeSpec.hs
@@ -50,6 +50,7 @@ spec = modifyMaxSize (const 20) $ modifyMaxSuccess (const 20) $ do
           {-# LANGUAGE DeriveGeneric #-}
           {-# LANGUAGE StandaloneDeriving #-}
 
+          import Prelude (Int, Show(..), (/=), ($), error, (++), unlines)
           import Generics.Eot
           import Control.Monad
 


### PR DESCRIPTION
This should make the quickcheck tests more reliable.